### PR TITLE
postgres keyword column names

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ toProperties:
   }
 ]
 ```
+>  **WARNING**: `excludedSourceColumns` and `excludedTargetColumns` are case sensetive. Usually for quoted values use upper case for Oracle (e.g. "COLUMN_VANE") and lower case for Postgres (e.g. "column_name"). In other cases use upper case.
 
 ### Step 2
 Halt any changes to the movable tables in the source database (Oracle)<br>

--- a/src/main/java/org/example/util/ColumnUtil.java
+++ b/src/main/java/org/example/util/ColumnUtil.java
@@ -16,6 +16,66 @@ import static org.example.util.SQLUtil.buildStartEndRowIdOfOracleChunk;
 public class ColumnUtil {
     private static final Logger logger = LogManager.getLogger(ColumnUtil.class);
 
+    // https://www.postgresql.org/docs/current/sql-keywords-appendix.html
+    private static final Set<String> KEYWORDS = Set.of(
+            "ALL",
+            "ANALYSE",
+            "ANALYZE",
+            "AND",
+            "ANY",
+            "ASC",
+            "ASYMMETRIC",
+            "BOTH",
+            "CASE",
+            "CAST",
+            "CHECK",
+            "COLLATE",
+            "COLUMN",
+            "CONSTRAINT",
+            "CURRENT_CATALOG",
+            "CURRENT_DATE",
+            "CURRENT_ROLE",
+            "CURRENT_TIME",
+            "CURRENT_TIMESTAMP",
+            "CURRENT_USER",
+            "DEFAULT",
+            "DEFERRABLE",
+            "DESC",
+            "DISTINCT",
+            "DO",
+            "ELSE",
+            "END",
+            "FALSE",
+            "FOREIGN",
+            "IN",
+            "INITIALLY",
+            "LATERAL",
+            "LEADING",
+            "LOCALTIME",
+            "LOCALTIMESTAMP",
+            "NOT",
+            "NULL",
+            "ONLY",
+            "OR",
+            "PLACING",
+            "PRIMARY",
+            "REFERENCES",
+            "SELECT",
+            "SESSION_USER",
+            "SOME",
+            "SYMMETRIC",
+            "SYSTEM_USER",
+            "TABLE",
+            "THEN",
+            "TRAILING",
+            "TRUE",
+            "UNIQUE",
+            "USER",
+            "USING",
+            "VARIADIC",
+            "WHEN"
+    );
+
     public static Map<String, Integer> readOraSourceColumns(Connection connection, Config config) {
         Map<String, Integer> columnMap = new TreeMap<>();
         ResultSet resultSet;
@@ -33,7 +93,7 @@ public class ColumnUtil {
             }
             resultSet.close();
         } catch (SQLException e) {
-            logger.error(e.getMessage());
+            logger.error(e.getMessage(), e);
         }
         return columnMap;
     }
@@ -57,7 +117,7 @@ public class ColumnUtil {
             }
             resultSet.close();
         } catch (SQLException e) {
-            logger.error(e.getMessage());
+            logger.error(e.getMessage(), e);
         }
         return columnMap;
     }
@@ -73,14 +133,17 @@ public class ColumnUtil {
                     null
             );
             while (resultSet.next()) {
-                String columnName = resultSet.getString(4);
+                String columnName = resultSet.getString(4).toUpperCase();
                 String columnType = resultSet.getString(6);
-                columnMap.put(columnName.toUpperCase(), columnType.equals("bigserial") ? "bigint" : columnType);
+                if(KEYWORDS.contains(columnName)){
+                    columnName = '"' + columnName.toLowerCase() + '"';
+                }
+                columnMap.put(columnName, columnType.equals("bigserial") ? "bigint" : columnType);
 //                System.out.println(columnName.toUpperCase() + " : " + (columnType.equals("bigserial") ? "bigint" : columnType));
             }
             resultSet.close();
         } catch (SQLException e) {
-            logger.error(e.getMessage());
+            logger.error(e.getMessage(), e);
         }
         return columnMap;
     }
@@ -127,7 +190,7 @@ public class ColumnUtil {
             resultSet.close();
             statement.close();
         } catch (SQLException e) {
-            logger.error(e.getMessage());
+            logger.error(e.getMessage(), e);
         }
         return chunkHashMap;
     }
@@ -152,7 +215,7 @@ public class ColumnUtil {
             resultSet.close();
             statement.close();
         } catch (SQLException e) {
-            logger.error(e);
+            logger.error(e.getMessage(), e);
         }
         return chunkHashMap;
     }
@@ -193,12 +256,12 @@ public class ColumnUtil {
                     resultSet.close();
                     preparedStatement.close();
                 } catch (SQLException e) {
-                    logger.error(e);
+                    logger.error(e.getMessage(), e);
                 }
             });
             createTable.close();
         } catch (SQLException e) {
-            logger.error(e);
+            logger.error(e.getMessage(), e);
         }
 
     }


### PR DESCRIPTION
Fixes data import for postgres columns which has name equal to postgres keywords (e.g. "primary", "offset" e.t.c.)

List of postgres keywords: https://www.postgresql.org/docs/current/sql-keywords-appendix.html

Also, stack traces added when logging exceptions